### PR TITLE
Rename `abrupt-comment` error to `abrupt-closing-of-comment`

### DIFF
--- a/lib/common/error_codes.js
+++ b/lib/common/error_codes.js
@@ -23,7 +23,7 @@ module.exports = {
     malformedComment: 'malformed-comment',
     eofInScriptHtmlComment: 'eof-in-script-html-comment',
     nestedComment: 'nested-comment',
-    abruptComment: 'abrupt-comment',
+    abruptClosingOfComment: 'abrupt-closing-of-comment',
     eofInComment: 'eof-in-comment',
     incorrectlyClosedComment: 'incorrectly-closed-comment',
     eofInCdata: 'eof-in-cdata',

--- a/lib/tokenizer/index.js
+++ b/lib/tokenizer/index.js
@@ -1625,7 +1625,7 @@ _[COMMENT_START_STATE] = function commentStartState(cp) {
         this.state = COMMENT_START_DASH_STATE;
 
     else if (cp === $.GREATER_THAN_SIGN) {
-        this._err(ERR.abruptComment);
+        this._err(ERR.abruptClosingOfComment);
         this.state = DATA_STATE;
         this._emitCurrentToken();
     }
@@ -1642,7 +1642,7 @@ _[COMMENT_START_DASH_STATE] = function commentStartDashState(cp) {
         this.state = COMMENT_END_STATE;
 
     else if (cp === $.GREATER_THAN_SIGN) {
-        this._err(ERR.abruptComment);
+        this._err(ERR.abruptClosingOfComment);
         this.state = DATA_STATE;
         this._emitCurrentToken();
     }


### PR DESCRIPTION
Closes HTMLParseErrorWG/meta#10
\cc @diervo 