### PR TITLE
Add null character error reporting for bogus doctype and comment per current spec changes

### DIFF
--- a/lib/tokenizer/index.js
+++ b/lib/tokenizer/index.js
@@ -1592,8 +1592,10 @@ _[BOGUS_COMMENT_STATE] = function bogusCommentState(cp) {
         this._emitEOFToken();
     }
 
-    else if (cp === $.NULL)
+    else if (cp === $.NULL) {
+        this._err(ERR.unexpectedNullCharacter);
         this.currentToken.data += unicode.REPLACEMENT_CHARACTER;
+    }
 
     else
         this.currentToken.data += toChar(cp);
@@ -1943,7 +1945,7 @@ _[AFTER_DOCTYPE_NAME_STATE] = function afterDoctypeNameState(cp) {
     else if (!this._ensureHibernation()) {
         this._err(ERR.invalidCharacterSequenceAfterDoctypeName);
         this.currentToken.forceQuirks = true;
-        this.state = BOGUS_DOCTYPE_STATE;
+        this._reconsumeInState(BOGUS_DOCTYPE_STATE);
     }
 };
 
@@ -1983,7 +1985,7 @@ _[AFTER_DOCTYPE_PUBLIC_KEYWORD_STATE] = function afterDoctypePublicKeywordState(
     else {
         this._err(ERR.missingQuoteBeforeDoctypePublicIdentifier);
         this.currentToken.forceQuirks = true;
-        this.state = BOGUS_DOCTYPE_STATE;
+        this._reconsumeInState(BOGUS_DOCTYPE_STATE);
     }
 };
 
@@ -2118,7 +2120,7 @@ _[AFTER_DOCTYPE_PUBLIC_IDENTIFIER_STATE] = function afterDoctypePublicIdentifier
     else {
         this._err(ERR.missingQuoteBeforeDoctypeSystemIdentifier);
         this.currentToken.forceQuirks = true;
-        this.state = BOGUS_DOCTYPE_STATE;
+        this._reconsumeInState(BOGUS_DOCTYPE_STATE);
     }
 };
 
@@ -2194,7 +2196,7 @@ _[AFTER_DOCTYPE_SYSTEM_KEYWORD_STATE] = function afterDoctypeSystemKeywordState(
     else {
         this._err(ERR.missingQuoteBeforeDoctypeSystemIdentifier);
         this.currentToken.forceQuirks = true;
-        this.state = BOGUS_DOCTYPE_STATE;
+        this._reconsumeInState(BOGUS_DOCTYPE_STATE);
     }
 };
 
@@ -2317,7 +2319,7 @@ _[AFTER_DOCTYPE_SYSTEM_IDENTIFIER_STATE] = function afterDoctypeSystemIdentifier
 
     else {
         this._err(ERR.unexpectedCharacterAfterDoctypeSystemIdentifier);
-        this.state = BOGUS_DOCTYPE_STATE;
+        this._reconsumeInState(BOGUS_DOCTYPE_STATE);
     }
 };
 
@@ -2329,6 +2331,9 @@ _[BOGUS_DOCTYPE_STATE] = function bogusDoctypeState(cp) {
         this._emitCurrentToken();
         this.state = DATA_STATE;
     }
+
+    else if (cp === $.NULL)
+        this._err(ERR.unexpectedNullCharacter);
 
     else if (cp === $.EOF) {
         this._emitCurrentToken();


### PR DESCRIPTION
Can be merged once https://github.com/html5lib/html5lib-tests/pull/103 merged and WG tests fork updated.