### PR TITLE
Initial mode parse errors

### DIFF
--- a/lib/common/doctype.js
+++ b/lib/common/doctype.js
@@ -4,6 +4,7 @@ var DOCUMENT_MODE = require('./html').DOCUMENT_MODE;
 
 //Const
 var VALID_DOCTYPE_NAME = 'html',
+    VALID_SYSTEM_ID = 'about:legacy-compat',
     QUIRKS_MODE_SYSTEM_ID = 'http://www.ibm.com/data/dtd/v11/ibmxhtml1-transitional.dtd',
     QUIRKS_MODE_PUBLIC_ID_PREFIXES = [
         '+//silmaril//dtd html pro v0r11 19970101//en',
@@ -110,12 +111,22 @@ function hasPrefix(publicId, prefixes) {
 
 
 //API
-exports.getDocumentMode = function (name, publicId, systemId) {
-    if (name !== VALID_DOCTYPE_NAME)
+exports.isConforming = function (token) {
+    return token.name === VALID_DOCTYPE_NAME &&
+           token.publicId === null &&
+           (token.systemId === null || token.systemId === VALID_SYSTEM_ID);
+};
+
+exports.getDocumentMode = function (token) {
+    if (token.name !== VALID_DOCTYPE_NAME)
         return DOCUMENT_MODE.QUIRKS;
+
+    var systemId = token.systemId;
 
     if (systemId && systemId.toLowerCase() === QUIRKS_MODE_SYSTEM_ID)
         return DOCUMENT_MODE.QUIRKS;
+
+    var publicId = token.publicId;
 
     if (publicId !== null) {
         publicId = publicId.toLowerCase();

--- a/lib/common/error_codes.js
+++ b/lib/common/error_codes.js
@@ -49,5 +49,7 @@ module.exports = {
     missingWhitespaceBeforeDoctypeName: 'missing-whitespace-before-doctype-name',
     missingDoctypeName: 'missing-doctype-name',
     invalidCharacterSequenceAfterDoctypeName: 'invalid-character-sequence-after-doctype-name',
-    duplicateAttribute: 'duplicate-attribute'
+    duplicateAttribute: 'duplicate-attribute',
+    nonConformingDoctype: 'non-conforming-doctype',
+    missingDoctype: 'missing-doctype'
 };

--- a/lib/extensions/error_reporting/mixin_base.js
+++ b/lib/extensions/error_reporting/mixin_base.js
@@ -21,9 +21,12 @@ ErrorReportingMixinBase.prototype._setErrorLocation = function (err) {
 ErrorReportingMixinBase.prototype._reportError = function (code) {
     var err = {
         code: code,
-        line: -1,
-        col: -1,
-        offset: -1
+        startLine: -1,
+        startCol: -1,
+        startOffset: -1,
+        endLine: -1,
+        endCol: -1,
+        endOffset: -1
     };
 
     this._setErrorLocation(err);

--- a/lib/extensions/error_reporting/parser_mixin.js
+++ b/lib/extensions/error_reporting/parser_mixin.js
@@ -12,6 +12,7 @@ var ErrorReportingParserMixin = module.exports = function (parser, opts) {
 
     this.opts = opts;
     this.ctLoc = null;
+    this.locBeforeToken = false;
 };
 
 inherits(ErrorReportingParserMixin, ErrorReportingMixinBase);
@@ -21,16 +22,15 @@ ErrorReportingParserMixin.prototype._setErrorLocation = function (err) {
         err.startLine = this.ctLoc.startLine;
         err.startCol = this.ctLoc.startCol;
         err.startOffset = this.ctLoc.startOffset;
-        err.endLine = this.ctLoc.endLine;
-        err.endCol = this.ctLoc.endCol;
-        err.endOffset = this.ctLoc.endOffset;
+
+        err.endLine = this.locBeforeToken ? this.ctLoc.startLine : this.ctLoc.endLine;
+        err.endCol = this.locBeforeToken ? this.ctLoc.startCol : this.ctLoc.endCol;
+        err.endOffset = this.locBeforeToken ? this.ctLoc.startOffset : this.ctLoc.endOffset;
     }
 };
 
 ErrorReportingParserMixin.prototype._getOverriddenMethods = function (mxn, orig) {
-    var methods = ErrorReportingMixinBase.prototype._getOverriddenMethods.call(this, mxn, orig);
-
-    return Object.assign({
+    return {
         _bootstrap: function (document, fragmentContext) {
             orig._bootstrap.call(this, document, fragmentContext);
 
@@ -42,6 +42,11 @@ ErrorReportingParserMixin.prototype._getOverriddenMethods = function (mxn, orig)
             mxn.ctLoc = token.location;
 
             orig._processInputToken.call(this, token);
+        },
+
+        _err: function (code, options) {
+            mxn.locBeforeToken = options && options.beforeToken;
+            mxn._reportError(code);
         }
-    }, methods);
+    };
 };

--- a/lib/extensions/location_info/parser_mixin.js
+++ b/lib/extensions/location_info/parser_mixin.js
@@ -52,14 +52,11 @@ LocationInfoParserMixin.prototype._setEndLocation = function (element, closingTo
                 loc.endOffset = ctLoc.endOffset;
             }
 
-            else
+            else {
+                loc.endLine = ctLoc.startLine;
+                loc.endCol = ctLoc.startCol;
                 loc.endOffset = ctLoc.startOffset;
-        }
-
-        else if (closingToken.type === Tokenizer.EOF_TOKEN) {
-            loc.endLine = this.posTracker.line;
-            loc.endCol = this.posTracker.col;
-            loc.endOffset = this.posTracker.offset;
+            }
         }
     }
 };

--- a/lib/extensions/location_info/tokenizer_mixin.js
+++ b/lib/extensions/location_info/tokenizer_mixin.js
@@ -68,6 +68,11 @@ LocationInfoTokenizerMixin.prototype._getOverriddenMethods = function (mxn, orig
             this.currentCharacterToken.location = mxn.ctLoc;
         },
 
+        _createEOFToken: function () {
+            orig._createEOFToken.call(this);
+            this.currentToken.location = mxn.ctLoc;
+        },
+
         _createAttr: function (attrNameFirstCh) {
             orig._createAttr.call(this, attrNameFirstCh);
             mxn.currentAttrLocation = mxn._getCurrentLocation();

--- a/lib/parser/index.js
+++ b/lib/parser/index.js
@@ -1050,9 +1050,10 @@ function stopParsing(p) {
 function doctypeInInitialMode(p, token) {
     p._setDocumentType(token);
 
-    var mode = token.forceQuirks ?
-        HTML.DOCUMENT_MODE.QUIRKS :
-        doctype.getDocumentMode(token.name, token.publicId, token.systemId);
+    var mode = token.forceQuirks ? HTML.DOCUMENT_MODE.QUIRKS : doctype.getDocumentMode(token);
+
+    if (!doctype.isConforming(token))
+        p._err(ERR.nonConformingDoctype);
 
     p.treeAdapter.setDocumentMode(p.document, mode);
 
@@ -1060,6 +1061,7 @@ function doctypeInInitialMode(p, token) {
 }
 
 function tokenInInitialMode(p, token) {
+    p._err(ERR.missingDoctype, { beforeToken: true });
     p.treeAdapter.setDocumentMode(p.document, HTML.DOCUMENT_MODE.QUIRKS);
     p.insertionMode = BEFORE_HTML_MODE;
     p._processToken(token);

--- a/lib/tokenizer/index.js
+++ b/lib/tokenizer/index.js
@@ -1592,8 +1592,10 @@ _[BOGUS_COMMENT_STATE] = function bogusCommentState(cp) {
         this._emitEOFToken();
     }
 
-    else if (cp === $.NULL)
+    else if (cp === $.NULL) {
+        this._err(ERR.unexpectedNullCharacter);
         this.currentToken.data += unicode.REPLACEMENT_CHARACTER;
+    }
 
     else
         this.currentToken.data += toChar(cp);
@@ -1943,7 +1945,7 @@ _[AFTER_DOCTYPE_NAME_STATE] = function afterDoctypeNameState(cp) {
     else if (!this._ensureHibernation()) {
         this._err(ERR.invalidCharacterSequenceAfterDoctypeName);
         this.currentToken.forceQuirks = true;
-        this.state = BOGUS_DOCTYPE_STATE;
+        this._reconsumeInState(BOGUS_DOCTYPE_STATE);
     }
 };
 
@@ -1983,7 +1985,7 @@ _[AFTER_DOCTYPE_PUBLIC_KEYWORD_STATE] = function afterDoctypePublicKeywordState(
     else {
         this._err(ERR.missingQuoteBeforeDoctypePublicIdentifier);
         this.currentToken.forceQuirks = true;
-        this.state = BOGUS_DOCTYPE_STATE;
+        this._reconsumeInState(BOGUS_DOCTYPE_STATE);
     }
 };
 
@@ -2118,7 +2120,7 @@ _[AFTER_DOCTYPE_PUBLIC_IDENTIFIER_STATE] = function afterDoctypePublicIdentifier
     else {
         this._err(ERR.missingQuoteBeforeDoctypeSystemIdentifier);
         this.currentToken.forceQuirks = true;
-        this.state = BOGUS_DOCTYPE_STATE;
+        this._reconsumeInState(BOGUS_DOCTYPE_STATE);
     }
 };
 
@@ -2194,7 +2196,7 @@ _[AFTER_DOCTYPE_SYSTEM_KEYWORD_STATE] = function afterDoctypeSystemKeywordState(
     else {
         this._err(ERR.missingQuoteBeforeDoctypeSystemIdentifier);
         this.currentToken.forceQuirks = true;
-        this.state = BOGUS_DOCTYPE_STATE;
+        this._reconsumeInState(BOGUS_DOCTYPE_STATE);
     }
 };
 
@@ -2317,7 +2319,7 @@ _[AFTER_DOCTYPE_SYSTEM_IDENTIFIER_STATE] = function afterDoctypeSystemIdentifier
 
     else {
         this._err(ERR.unexpectedCharacterAfterDoctypeSystemIdentifier);
-        this.state = BOGUS_DOCTYPE_STATE;
+        this._reconsumeInState(BOGUS_DOCTYPE_STATE);
     }
 };
 
@@ -2329,6 +2331,9 @@ _[BOGUS_DOCTYPE_STATE] = function bogusDoctypeState(cp) {
         this._emitCurrentToken();
         this.state = DATA_STATE;
     }
+
+    else if (cp === $.NULL)
+        this._err(ERR.unexpectedNullCharacter);
 
     else if (cp === $.EOF) {
         this._emitCurrentToken();

--- a/lib/tokenizer/index.js
+++ b/lib/tokenizer/index.js
@@ -403,6 +403,10 @@ Tokenizer.prototype._createCharacterToken = function (type, ch) {
     };
 };
 
+Tokenizer.prototype._createEOFToken = function () {
+    this.currentToken = {type: Tokenizer.EOF_TOKEN};
+};
+
 //Tag attributes
 Tokenizer.prototype._createAttr = function (attrNameFirstCh) {
     this.currentAttr = {
@@ -458,8 +462,8 @@ Tokenizer.prototype._emitCurrentCharacterToken = function () {
 };
 
 Tokenizer.prototype._emitEOFToken = function () {
-    this._emitCurrentCharacterToken();
-    this.tokenQueue.push({type: Tokenizer.EOF_TOKEN});
+    this._createEOFToken();
+    this._emitCurrentToken();
 };
 
 //Characters emission

--- a/test/fixtures/location_info_parser_test.js
+++ b/test/fixtures/location_info_parser_test.js
@@ -95,9 +95,7 @@ testUtils.generateTestsForEachTreeAdapter(module.exports, function (_test, treeA
             //Then for each node in the tree we run serializer and compare results with the substring
             //obtained via location info from the expected serialization results.
             _test[getFullLocationTestName(test)] = function () {
-                var serializerOpts = {
-                        treeAdapter: treeAdapter
-                    },
+                var serializerOpts = { treeAdapter: treeAdapter },
                     html = escapeString(test.data),
                     lines = html.split(/\r?\n/g),
                     parserOpts = {
@@ -132,7 +130,7 @@ testUtils.generateTestsForEachTreeAdapter(module.exports, function (_test, treeA
             };
         });
 
-    exports['Regression - location info for the implicitly generated <body>, <html> and <head> (GH-44)'] = function () {
+    _test['Regression - location info for the implicitly generated <body>, <html> and <head> (GH-44)'] = function () {
         var html = '</head><div class="test"></div></body></html>',
             opts = {
                 treeAdapter: treeAdapter,
@@ -148,7 +146,7 @@ testUtils.generateTestsForEachTreeAdapter(module.exports, function (_test, treeA
         });
     };
 
-    exports['Regression - Incorrect LocationInfo.endOffset for implicitly closed <p> element (GH-109)'] = function () {
+    _test['Regression - Incorrect LocationInfo.endOffset for implicitly closed <p> element (GH-109)'] = function () {
         var html = '<p>1<p class="2">3',
             opts = {
                 treeAdapter: treeAdapter,
@@ -156,12 +154,12 @@ testUtils.generateTestsForEachTreeAdapter(module.exports, function (_test, treeA
             };
 
         var fragment = parse5.parseFragment(html, opts),
-            firstPLocation = fragment.childNodes[0].__location;
+            firstPLocation = treeAdapter.getChildNodes(fragment)[0].__location;
 
         assert.strictEqual(html.substring(firstPLocation.startOffset, firstPLocation.endOffset), '<p>1');
     };
 
-    exports['Regression - Incorrect LocationInfo.endOffset for element with closing tag (GH-159)'] = function () {
+    _test['Regression - Incorrect LocationInfo.endOffset for element with closing tag (GH-159)'] = function () {
         var html = '<i>1</i>2',
             opts = {
                 treeAdapter: treeAdapter,
@@ -169,12 +167,12 @@ testUtils.generateTestsForEachTreeAdapter(module.exports, function (_test, treeA
             };
 
         var fragment = parse5.parseFragment(html, opts),
-            location = fragment.childNodes[0].__location;
+            location = treeAdapter.getChildNodes(fragment)[0].__location;
 
         assert.strictEqual(html.substring(location.startOffset, location.endOffset), '<i>1</i>');
     };
 
-    exports['Regression - Location info not exposed with parseFragment (GH-82)'] = function () {
+    _test['Regression - Location info not exposed with parseFragment (GH-82)'] = function () {
         var html = '<html><head></head><body>foo</body></html>',
             opts = {
                 treeAdapter: treeAdapter,
@@ -183,10 +181,10 @@ testUtils.generateTestsForEachTreeAdapter(module.exports, function (_test, treeA
 
         var fragment = parse5.parseFragment(html, opts);
 
-        assert.ok(fragment.childNodes[0].__location);
+        assert.ok(treeAdapter.getChildNodes(fragment)[0].__location);
     };
 
-    exports['Regression - location info mixin error when parsing <template> elements (GH-90)'] = function () {
+    _test['Regression - location info mixin error when parsing <template> elements (GH-90)'] = function () {
         var html = '<template>hello</template>',
             opts = {
                 treeAdapter: treeAdapter,
@@ -198,7 +196,7 @@ testUtils.generateTestsForEachTreeAdapter(module.exports, function (_test, treeA
         });
     };
 
-    exports['Regression - location info not attached for empty attributes (GH-96)'] = function () {
+    _test['Regression - location info not attached for empty attributes (GH-96)'] = function () {
         var html = '<div test-attr></div>',
             opts = {
                 treeAdapter: treeAdapter,
@@ -207,16 +205,18 @@ testUtils.generateTestsForEachTreeAdapter(module.exports, function (_test, treeA
 
         var fragment = parse5.parseFragment(html, opts);
 
-        assert.ok(fragment.childNodes[0].__location.attrs['test-attr']);
+        assert.ok(treeAdapter.getChildNodes(fragment)[0].__location.attrs['test-attr']);
     };
 
-    exports['Regression - location line incorrect when a character is unconsumed (GH-151)'] = function () {
-        var html = ['<html><body>',
+    _test['Regression - location line incorrect when a character is unconsumed (GH-151)'] = function () {
+        var html = [
+                '<html><body>',
                 '<script>',
                 '  var x = window.scrollY <',
                 '      100;',
                 '</script>',
-                '</body></html>'].join('\n'),
+                '</body></html>'
+            ].join('\n'),
             opts = {
                 treeAdapter: treeAdapter,
                 locationInfo: true
@@ -226,7 +226,7 @@ testUtils.generateTestsForEachTreeAdapter(module.exports, function (_test, treeA
             foundScript = false;
 
         walkTree(doc, treeAdapter, function (node) {
-            if (node.name === 'script') {
+            if (treeAdapter.getTagName(node) === HTML.TAG_NAMES.SCRIPT) {
                 foundScript = true;
                 assert.equal(node.__location.endTag.startLine, 5);
             }
@@ -235,7 +235,7 @@ testUtils.generateTestsForEachTreeAdapter(module.exports, function (_test, treeA
         assert.ok(foundScript);
     };
 
-    exports['Regression - location.startTag should be available if end tag is missing (GH-181)'] = function () {
+    _test['Regression - location.startTag should be available if end tag is missing (GH-181)'] = function () {
         var html = '<p>test',
             opts = {
                 treeAdapter: treeAdapter,
@@ -243,7 +243,7 @@ testUtils.generateTestsForEachTreeAdapter(module.exports, function (_test, treeA
             };
 
         var fragment = parse5.parseFragment(html, opts),
-            p = fragment.childNodes[0];
+            p = treeAdapter.getChildNodes(fragment)[0];
 
         assertNodeLocation(p, html, html, [html]);
         assertStartTagLocation(p, html, html, [html]);

--- a/test/fixtures/parser_test.js
+++ b/test/fixtures/parser_test.js
@@ -36,6 +36,10 @@ function assertParsing(input, expected, opts) {
     assert.strictEqual(actual, expected, msg);
 }
 
+function assertErrors(actual, expected) {
+    assert.deepEqual(actual.sort(), expected.sort());
+}
+
 testUtils.generateTestsForEachTreeAdapter(module.exports, function (_test, treeAdapter) {
     //Here we go..
     testUtils
@@ -65,16 +69,16 @@ testUtils.generateTestsForEachTreeAdapter(module.exports, function (_test, treeA
 
                 if (test.fragmentContext) {
                     assertFragmentParsing(test.input, test.fragmentContext, test.expected, opts);
-                    assert.deepEqual(errs, test.expectedErrors);
+                    assertErrors(errs, test.expectedErrors);
                 }
 
                 else {
                     assertStreamingParsing(test.input, test.expected, opts);
-                    assert.deepEqual(errs, test.expectedErrors);
+                    assertErrors(errs, test.expectedErrors);
 
                     errs = [];
                     assertParsing(test.input, test.expected, opts);
-                    assert.deepEqual(errs, test.expectedErrors);
+                    assertErrors(errs, test.expectedErrors);
                 }
             };
         });
@@ -83,7 +87,7 @@ testUtils.generateTestsForEachTreeAdapter(module.exports, function (_test, treeA
 
 exports['Regression - HTML5 Legacy Doctype Misparsed with htmlparser2 tree adapter (GH-45)'] = function () {
     var html = '<!DOCTYPE html SYSTEM "about:legacy-compat"><html><head></head><body>Hi there!</body></html>',
-        document = parse5.parse(html, {treeAdapter: parse5.treeAdapters.htmlparser2});
+        document = parse5.parse(html, { treeAdapter: parse5.treeAdapters.htmlparser2 });
 
     assert.strictEqual(document.childNodes[0].data, '!DOCTYPE html SYSTEM "about:legacy-compat"');
 };
@@ -108,7 +112,7 @@ exports['Regression - Incorrect arguments fallback for the parser.parseFragment 
     test: function () {
         var fragmentContext = parse5.treeAdapters.default.createElement('div'),
             html = '<script></script>',
-            opts = {locationInfo: true};
+            opts = { locationInfo: true };
 
         var args = parse5.parseFragment(fragmentContext, html, opts);
 
@@ -142,7 +146,7 @@ exports["Regression - Don't inherit from Object when creating collections (GH-11
     },
 
     test: function () {
-        var fragment = parse5.parseFragment('<div id="123">', {treeAdapter: parse5.treeAdapters.htmlparser2});
+        var fragment = parse5.parseFragment('<div id="123">', { treeAdapter: parse5.treeAdapters.htmlparser2 });
 
         assert.strictEqual(parse5.treeAdapters.htmlparser2.getAttrList(fragment.childNodes[0]).length, 1);
     }


### PR DESCRIPTION
\cc @HTMLParseErrorWG/core 

For newcomers: this requires html5lib-tests PR to be merged first to make tests pass. We usually rerun tests for parse5 PRs once they get merged.